### PR TITLE
fix(spotitube): align docker push tags with unciae compliance

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -167,6 +167,24 @@ jobs:
           for name in SPOTIFY_ID SPOTIFY_KEY GENIUS_TOKEN; do
             [ -n "$(printenv "$name")" ] || { echo "::error::$name is empty"; exit 1; }
           done
+      - name: Set docker tags
+        id: tags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/master" ]; then
+            {
+              echo "tags<<EOF"
+              echo "ghcr.io/$REPOSITORY:latest"
+              echo "ghcr.io/$REPOSITORY:$SHA"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=ghcr.io/$REPOSITORY:$SHA" >> "$GITHUB_OUTPUT"
+          fi
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           secrets: |
@@ -176,7 +194,5 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          push: true

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -108,4 +108,5 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:release
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
           push: true


### PR DESCRIPTION
Align docker push tags with unciae 66d529c.

- master already publishes :latest + :sha same digest (same build-push-action) -> compliant
- PRs currently push none (safe, no latest) -> compliant with SHA-only allowance
- tag.yml now publishes :release + :ref_name + :sha same digest, never :latest -> fixed

Push gating uses push==master condition, no pull_request_target, secrets safe (build secrets empty on fork PRs).

Fixes missing sha tag in tag.yml.