### PR TITLE
ci(spotitube): disable benchmarking, align docker push tags

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -126,18 +126,6 @@ jobs:
           repository: streambinder/streambinder
           event-type: doc-sync
           client-payload: '{"repo": "${{ github.repository }}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
-  benchmark:
-    runs-on: ubuntu-latest
-    needs: [test]
-    if: success()
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
-        with:
-          go-version-file: go.mod
-      - run: go test -gcflags="all=-N -l" -benchmem -bench '^Benchmark.*$' ./... | grep ^Benchmark
   build:
     runs-on: ubuntu-24.04-arm
     needs: [test]
@@ -167,6 +155,24 @@ jobs:
           for name in SPOTIFY_ID SPOTIFY_KEY GENIUS_TOKEN; do
             [ -n "$(printenv "$name")" ] || { echo "::error::$name is empty"; exit 1; }
           done
+      - name: Set docker tags
+        id: tags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/master" ]; then
+            {
+              echo "tags<<EOF"
+              echo "ghcr.io/$REPOSITORY:latest"
+              echo "ghcr.io/$REPOSITORY:$SHA"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=ghcr.io/$REPOSITORY:$SHA" >> "$GITHUB_OUTPUT"
+          fi
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           secrets: |
@@ -176,7 +182,5 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          push: true

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -108,4 +108,5 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:release
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
           push: true


### PR DESCRIPTION
Removes benchmark job from push.yml (too long/heavy, little value). Also includes docker tag compliance from #202 (Set docker tags – master latest+sha, PRs sha-only) and tag.yml sha tag. Supersedes #202.