### PR TITLE
fix(youtube): sanitize hyphen operators in search query

### DIFF
--- a/provider/youtube.go
+++ b/provider/youtube.go
@@ -98,11 +98,19 @@ func init() {
 	providers = append(providers, youTube{})
 }
 
+func sanitizeYouTubeQuery(q string) string {
+	// YouTube interprets -word as exclusion operator, filter out hyphens
+	// to avoid unintended query filtering
+	q = strings.ReplaceAll(q, "-", " ")
+	return strings.Join(strings.Fields(q), " ")
+}
+
 func (provider youTube) search(track *entity.Track) ([]*Match, error) {
 	query := track.Title
 	for _, artist := range track.Artists {
 		query = fmt.Sprintf("%s %s", query, artist)
 	}
+	query = sanitizeYouTubeQuery(query)
 
 	for attempt := 0; attempt < sys.MaxRetries; attempt++ {
 		matches, retry, err := func() ([]*Match, bool, error) {


### PR DESCRIPTION
Fixes #204

**Problem:** Titles like `Memories of You -Reload-` or `Departures 〜...〜 -BOOM BOOM SATELLITES Remix-` build YouTube queries with `-word` which YouTube interprets as exclusion operator (`-word` = exclude). Result: 0 results or fan covers, while removing hyphens returns official video.

**Solution (Option A from issue):** Sanitize query before search – replace hyphens with spaces and collapse whitespace.

```go
func sanitizeYouTubeQuery(q string) string {
  q = strings.ReplaceAll(q, "-", " ")
  return strings.Join(strings.Fields(q), " ")
}
```

- Simple, minimal
- YouTube is tolerant to missing hyphens, official videos still rank first
- Preserves existing retry/429 logic

Closes #204