### PR TITLE
fix(anchor): guard style write in Lot.Close with lock

### DIFF
--- a/sys/anchor/lot.go
+++ b/sys/anchor/lot.go
@@ -50,9 +50,11 @@ func (lot *Lot) Wipe() {
 }
 
 func (lot *Lot) Close(messages ...string) {
+	lot.window.lock.Lock()
 	if !lot.window.plain {
 		lot.style = idleColor
 	}
+	lot.window.lock.Unlock()
 	lot.Print(sys.First(messages, "done"))
 }
 


### PR DESCRIPTION
Fixes data race in sys/anchor/lot.go.

Close() wrote lot.style without holding window lock, while concurrent Print() iterates lots and reads style in write().

Hold window lock around style mutation, matching existing lock usage in Print/write.

Race was reported in actions run 32475335533 job 96751067716.

note: spotitube | delegate: pr | commit: fix(anchor): guard style write in Lot.Close with lock | token: classic